### PR TITLE
Fix broken mapping

### DIFF
--- a/mappings/net/minecraft/world/gen/layer/BiomeSampler.mapping
+++ b/mappings/net/minecraft/world/gen/layer/BiomeSampler.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_166 net/minecraft/world/gen/layer/BiomeSampler
 		METHOD method_3143 getBiome (II)Lnet/minecraft/class_145;
 	METHOD <init> (Lnet/minecraft/class_144;)V
 		ARG 1 source
-	METHOD a (II)Lnet/minecraft/class_166$class_944;
+	METHOD method_3139 (II)Lnet/minecraft/class_166$class_944;
 		ARG 1 x
 		ARG 2 z
 	METHOD method_3141 getBiome (II)Lnet/minecraft/class_145;


### PR DESCRIPTION
There were 9 methods and 11 fields with invalid Intermediary descriptors, think this is the only one that had a Yarn name though